### PR TITLE
Autodetect only CircuitPython serial ports when serial is not specified

### DIFF
--- a/piku/commands/serial.py
+++ b/piku/commands/serial.py
@@ -1,14 +1,12 @@
 from serial import Serial
 from serial.serialutil import SerialException
-from serial.tools import list_ports
 from serial.tools.miniterm import Miniterm
+import adafruit_board_toolkit.circuitpython_serial
+
 
 
 def default():
-    ports = list_ports.comports()
-    # On macOS, we don't want to return the Bluetooth COM ports and
-    # on other platforms we may only want usb serial devices as well
-    ports = [p for p in ports if 'usb' in p.hwid.lower()]
+    ports = adafruit_board_toolkit.circuitpython_serial.repl_comports()
     if not ports:
         return None
     return ports[0].device

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,15 @@
 [[package]]
+name = "adafruit-board-toolkit"
+version = "1.1.0"
+description = "CircuitPython board identification and information"
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.dependencies]
+pyserial = "*"
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -316,9 +327,12 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "63e610798081242e4aa4e40a7caed9e97cf29ac3f899a1d48478a5888b9cdad8"
+content-hash = "0c1e8397b348ab9385804f4f0ecfd3e07078f00c611d5b0b33493b41a7d8431d"
 
 [metadata.files]
+adafruit-board-toolkit = [
+    {file = "adafruit-board-toolkit-1.1.0.tar.gz", hash = "sha256:61e19c30854764230138f4c1d65bf3b5d6ef22866396b231df7123a5a2507f27"},
+]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ toml = "^0.10.2"
 appdirs = "^1.4.4"
 requests = "^2.27.1"
 Jinja2 = "^3.0.3"
+adafruit-board-toolkit = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
PR for issue #5 

One thought occurred to me, does the Adafruit Board Toolkit detect other manufacturers boards?